### PR TITLE
Derive `Default` for `ByteUnit`

### DIFF
--- a/src/byte_unit.rs
+++ b/src/byte_unit.rs
@@ -80,7 +80,7 @@
 /// assert_eq!(too_small, 0);
 /// ```
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Eq, Hash, Ord)]
+#[derive(Debug, Copy, Clone, Eq, Hash, Ord, Default)]
 pub struct ByteUnit(pub(crate) u64);
 
 macro_rules! rem_and_suffix {


### PR DESCRIPTION
Deriving `Default` for `ByteUnit` makes sense because `0u64` is a sensible default. This reduces friction for downstream projects where a field of a struct that derives `Default` is a `ByteUnit`.