### PR TITLE
Add `as_usize` convenience method

### DIFF
--- a/src/byte_unit.rs
+++ b/src/byte_unit.rs
@@ -219,6 +219,22 @@ impl ByteUnit {
         self.0 as u128
     }
 
+    /// Returns the value of bytes represented by `self` as a `usize`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use ubyte::ByteUnit;
+    /// let int: usize = ByteUnit::Gigabyte(4).as_usize();
+    /// assert_eq!(int, 4 * ByteUnit::GB);
+    ///
+    /// assert_eq!(ByteUnit::Megabyte(42).as_usize(), 42 * 1_000_000);
+    /// assert_eq!(ByteUnit::Exbibyte(7).as_usize(), 7 * 1 << 60);
+    /// ```
+    pub const fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+
     /// Returns the components of the minimal unit representation of `self`.
     ///
     /// The "minimal unit representation" is the representation that maximizes


### PR DESCRIPTION
Just a little convenience method for my own purposes. Useful when allocating buffers of a specific amount of bytes, where the size is expected to be a usize.
Previously you would have to write:
```rust
4.mebibytes.as_u64() as _
```
which is a bit clunky.