### PR TITLE
Support strings in self describing formats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"
+serde_json = "1"

--- a/src/ser_de.rs
+++ b/src/ser_de.rs
@@ -59,12 +59,12 @@ impl Serialize for ByteUnit {
 
 #[cfg(test)]
 mod serde_tests {
-    use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
+    use serde_test::{assert_de_tokens, assert_ser_tokens, Configure, Token};
     use crate::ByteUnit;
 
     #[test]
     fn test_de() {
-        let half_mib = ByteUnit::Kibibyte(512);
+        let half_mib = ByteUnit::Kibibyte(512).readable();
         assert_de_tokens(&half_mib, &[Token::Str("512 kib")]);
         assert_de_tokens(&half_mib, &[Token::Str("512 KiB")]);
         assert_de_tokens(&half_mib, &[Token::Str("512KiB")]);
@@ -74,12 +74,12 @@ mod serde_tests {
         assert_de_tokens(&half_mib, &[Token::I32(524288)]);
         assert_de_tokens(&half_mib, &[Token::I64(524288)]);
 
-        let one_mib = ByteUnit::Mebibyte(1);
+        let one_mib = ByteUnit::Mebibyte(1).readable();
         assert_de_tokens(&one_mib, &[Token::Str("1 mib")]);
         assert_de_tokens(&one_mib, &[Token::Str("1 MiB")]);
         assert_de_tokens(&one_mib, &[Token::Str("1mib")]);
 
-        let zero = ByteUnit::Byte(0);
+        let zero = ByteUnit::Byte(0).readable();
         assert_de_tokens(&zero, &[Token::Str("0")]);
         assert_de_tokens(&zero, &[Token::Str("0 B")]);
         assert_de_tokens(&zero, &[Token::U32(0)]);
@@ -89,14 +89,40 @@ mod serde_tests {
     }
 
     #[test]
-    fn test_ser() {
-        let half_mib = ByteUnit::Kibibyte(512);
+    fn test_de_compact() {
+        let half_mib = ByteUnit::Kibibyte(512).compact();
+        assert_de_tokens(&half_mib, &[Token::Str("512 kib")]);
+        assert_de_tokens(&half_mib, &[Token::Str("512 KiB")]);
+        assert_de_tokens(&half_mib, &[Token::Str("512KiB")]);
+        assert_de_tokens(&half_mib, &[Token::Str("524288")]);
+        assert_de_tokens(&half_mib, &[Token::U32(524288)]);
+        assert_de_tokens(&half_mib, &[Token::U64(524288)]);
+        assert_de_tokens(&half_mib, &[Token::I32(524288)]);
+        assert_de_tokens(&half_mib, &[Token::I64(524288)]);
+
+        let one_mib = ByteUnit::Mebibyte(1).compact();
+        assert_de_tokens(&one_mib, &[Token::Str("1 mib")]);
+        assert_de_tokens(&one_mib, &[Token::Str("1 MiB")]);
+        assert_de_tokens(&one_mib, &[Token::Str("1mib")]);
+
+        let zero = ByteUnit::Byte(0).compact();
+        assert_de_tokens(&zero, &[Token::Str("0")]);
+        assert_de_tokens(&zero, &[Token::Str("0 B")]);
+        assert_de_tokens(&zero, &[Token::U32(0)]);
+        assert_de_tokens(&zero, &[Token::U64(0)]);
+        assert_de_tokens(&zero, &[Token::I32(-34)]);
+        assert_de_tokens(&zero, &[Token::I64(-2483)]);
+    }
+
+    #[test]
+    fn test_ser_compact() {
+        let half_mib = ByteUnit::Kibibyte(512).compact();
         assert_ser_tokens(&half_mib, &[Token::U64(512 << 10)]);
 
-        let ten_bytes = ByteUnit::Byte(10);
+        let ten_bytes = ByteUnit::Byte(10).compact();
         assert_ser_tokens(&ten_bytes, &[Token::U64(10)]);
 
-        let zero = ByteUnit::Byte(0);
+        let zero = ByteUnit::Byte(0).compact();
         assert_de_tokens(&zero, &[Token::U64(0)]);
     }
 }

--- a/src/ser_de.rs
+++ b/src/ser_de.rs
@@ -117,4 +117,17 @@ mod serde_tests {
         let zero = ByteUnit::Byte(0).compact();
         assert_de_tokens(&zero, &[Token::U64(0)]);
     }
+
+    #[test]
+    fn test_ser_readable() {
+        // readable serialization forms are the same as compact
+        let half_mib = ByteUnit::Kibibyte(512).readable();
+        assert_ser_tokens(&half_mib, &[Token::U64(512 << 10)]);
+
+        let ten_bytes = ByteUnit::Byte(10).readable();
+        assert_ser_tokens(&ten_bytes, &[Token::U64(10)]);
+
+        let zero = ByteUnit::Byte(0).readable();
+        assert_de_tokens(&zero, &[Token::U64(0)]);
+    }
 }

--- a/src/ser_de.rs
+++ b/src/ser_de.rs
@@ -91,23 +91,15 @@ mod serde_tests {
     #[test]
     fn test_de_compact() {
         let half_mib = ByteUnit::Kibibyte(512).compact();
-        assert_de_tokens(&half_mib, &[Token::Str("512 kib")]);
-        assert_de_tokens(&half_mib, &[Token::Str("512 KiB")]);
-        assert_de_tokens(&half_mib, &[Token::Str("512KiB")]);
-        assert_de_tokens(&half_mib, &[Token::Str("524288")]);
         assert_de_tokens(&half_mib, &[Token::U32(524288)]);
         assert_de_tokens(&half_mib, &[Token::U64(524288)]);
         assert_de_tokens(&half_mib, &[Token::I32(524288)]);
         assert_de_tokens(&half_mib, &[Token::I64(524288)]);
 
         let one_mib = ByteUnit::Mebibyte(1).compact();
-        assert_de_tokens(&one_mib, &[Token::Str("1 mib")]);
-        assert_de_tokens(&one_mib, &[Token::Str("1 MiB")]);
-        assert_de_tokens(&one_mib, &[Token::Str("1mib")]);
+        assert_de_tokens(&one_mib, &[Token::U32(1024 * 1024)]);
 
         let zero = ByteUnit::Byte(0).compact();
-        assert_de_tokens(&zero, &[Token::Str("0")]);
-        assert_de_tokens(&zero, &[Token::Str("0 B")]);
         assert_de_tokens(&zero, &[Token::U32(0)]);
         assert_de_tokens(&zero, &[Token::U64(0)]);
         assert_de_tokens(&zero, &[Token::I32(-34)]);

--- a/src/ser_de.rs
+++ b/src/ser_de.rs
@@ -7,7 +7,13 @@ impl<'de> Deserialize<'de> for ByteUnit {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
-        deserializer.deserialize_u64(Visitor)
+        if deserializer.is_human_readable() {
+            // to support json and others, visit any
+            deserializer.deserialize_any(Visitor)
+        } else {
+            // hint for more compact that we expect an u64
+            deserializer.deserialize_u64(Visitor)
+        }
     }
 }
 

--- a/tests/with_serde_json.rs
+++ b/tests/with_serde_json.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "serde")]
+#[test]
+fn str_is_accepted() {
+    let input = r#""42 KiB""#;
+
+    let actual = serde_json::from_str::<ubyte::ByteUnit>(&input).unwrap();
+    assert_eq!(actual.as_u64(), 42 * 1024);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn u64_bytes_is_accepted() {
+    let input = r#"42"#;
+
+    let actual = serde_json::from_str::<ubyte::ByteUnit>(&input).unwrap();
+    assert_eq!(actual, 42);
+}


### PR DESCRIPTION
Fixes #7 by using `Deserializer::is_human_readable(&self)` to switch on asking `deserialize_any` or `deserialize_u64`.

First commit is a reproduction of the issue with `serde_json`. Happy to get rid of it.

Changes to the tests are not as straight-forward. I haven't used compact deserializers with serde but I would assume that it is rarely possible to switch deserializing an u64 to deserializing an str. Perhaps protobuf could do this, but protobuf is rarely if ever deserialized with serde. 