### PR TITLE
add `From` and `as_` implementations for usize

### DIFF
--- a/src/byte_unit.rs
+++ b/src/byte_unit.rs
@@ -219,6 +219,26 @@ impl ByteUnit {
         self.0 as u128
     }
 
+    /// Returns the value of bytes represented by `self` as a `usize`.
+    ///
+    /// Only present on architectures where `usize` can fit the internal
+    /// representation of byte size (64 bit).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use ubyte::ByteUnit;
+    /// let int: usize = ByteUnit::Gigabyte(4).as_usize();
+    /// assert_eq!(int, 4 * ByteUnit::GB);
+    ///
+    /// assert_eq!(ByteUnit::Megabyte(42).as_usize(), 42 * 1_000_000);
+    /// assert_eq!(ByteUnit::Exbibyte(7).as_usize(), 7 * 1 << 60);
+    /// ```
+    #[cfg(target_pointer_width = "64")]
+    pub const fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+
     /// Returns the components of the minimal unit representation of `self`.
     ///
     /// The "minimal unit representation" is the representation that maximizes
@@ -273,6 +293,13 @@ impl From<ByteUnit> for u128 {
     }
 }
 
+#[cfg(target_pointer_width = "64")]
+impl From<ByteUnit> for usize {
+    #[inline(always)]
+    fn from(v: ByteUnit) -> Self {
+        v.as_usize()
+    }
+}
 macro_rules! impl_from_int_unknown {
     ($T:ty) => (
         impl From<$T> for ByteUnit {


### PR DESCRIPTION
Some APIs expect size in bytes in `usize`, so I added a convenience method. To avoid hard-to-debug bugs, the methods are only present on 64 bit platforms that can fit `u64` into `usize`.